### PR TITLE
fix a path resolve BUG under Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ function apimock(configPath) {
       header: req.headers
     };
 
-    var filepath = _.template(path.join(configDir, route.response.file))(tmplParams);
+    var filepath = path.join(configDir, _.template(route.response.file)(tmplParams));
     var handleRes = handleResponse.bind(null, res);
 
     if (route.response.type === 'js') {

--- a/test/fixture/apimock.yml
+++ b/test/fixture/apimock.yml
@@ -46,7 +46,7 @@
     method: POST
   response:
     status: "<%= body.name ? 201 : 422 %>"
-    file: "json/users/<%= body.name ? 'created' : 'failed' %>.json"
+    file: "<%= body.name ? 'json/users/created' : 'json/users/failed' %>.json"
 
 - request:
     url: /api/users/js


### PR DESCRIPTION
when write '/' in file attribute, path.join will convert them to '\', this will case _.template get a wrong result
